### PR TITLE
chore: adjust to bpmn-io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to [`@philippfromme/moddle-helpers`](https://github.com/philippfromme/moddle-helpers) are documented here. We use [semantic versioning](http://semver.org/) for releases.
+All notable changes to [`@bpmn-io/moddle-helpers`](https://github.com/bpmn-io/moddle-helpers) are documented here. We use [semantic versioning](http://semver.org/) for releases.
 
 ## Unreleased
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Helpers for [moddle](https://github.com/bpmn-io/moddle).
 ## `getPath`
 
 ```javascript
-import { getPath } from '@philippfromme/moddle-helpers';
+import { getPath } from '@bpmn-io/moddle-helpers';
 
 // global
 getPath(moddleElement); // [ 'rootElements', 0, 'flowElements', 0, 'extensionElements', 'values', 0 ]
@@ -27,7 +27,7 @@ getPath(null); // null
 ## `pathConcat`
 
 ```javascript
-import { pathConcat } from '@philippfromme/moddle-helpers';
+import { pathConcat } from '@bpmn-io/moddle-helpers';
 
 pathConcat([ 'foo', 'bar' ], 'baz'); // [ 'foo', 'bar', 'baz' ]
 
@@ -38,7 +38,7 @@ pathConcat([ 'foo', 'bar' ], null); // null
 ## `pathEquals`
 
 ```javascript
-import { pathEquals } from '@philippfromme/moddle-helpers';
+import { pathEquals } from '@bpmn-io/moddle-helpers';
 
 // default separator
 pathEquals('extensionElements.values.0.type', 'extensionElements.values.0.type'); // true
@@ -55,7 +55,7 @@ pathEquals(null, [ 'foo' ]); // false
 ## `parsePath`
 
 ```javascript
-import { parsePath } from '@philippfromme/moddle-helpers';
+import { parsePath } from '@bpmn-io/moddle-helpers';
 
 // default separator
 parsePath('rootElements.0.flowElements.0.extensionElements.values.0.type'); // [ 'rootElements', 0, 'flowElements', 0, 'extensionElements', 'values', 0 ]
@@ -70,7 +70,7 @@ parsePath(null); // null
 ## `stringifyPath`
 
 ```javascript
-import { stringifyPath } from '@philippfromme/moddle-helpers';
+import { stringifyPath } from '@bpmn-io/moddle-helpers';
 
 // default separator
 stringifyPath([ 'rootElements', 0, 'flowElements', 0, 'extensionElements', 'values', 0 ]); // 'rootElements.0.flowElements.0.extensionElements.values.0.type'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@philippfromme/moddle-helpers",
+  "name": "@bpmn-io/moddle-helpers",
   "version": "0.4.1",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/philippfromme/moddle-helpers"
+    "url": "https://github.com/bpmn-io/moddle-helpers"
   },
   "keywords": [
     "moddle"


### PR DESCRIPTION
The goal is to release this project as `@bpmn-io/moddle-helpers` (analogous to [bpmnlint-utils](https://github.com/bpmn-io/bpmnlint-utils)). bpmn.io projects like [`bpmnlint-plugin-camunda-compat`](https://github.com/camunda/bpmnlint-plugin-camunda-compat/) are currently using [`@philippfromme/moddle-helpers`](https://www.npmjs.com/package/@philippfromme/moddle-helpers).
